### PR TITLE
[12] Fix sign toggle key not working with subtraction operator

### DIFF
--- a/.clinerules/06-github-workflow.md
+++ b/.clinerules/06-github-workflow.md
@@ -41,3 +41,14 @@ When working on a GitHub issue (#X):
 - Ensure all CI checks pass before creating or requesting review of a PR
 - Create PR titled: `[{issue_id}] {short summary}`
 - PR body must include: "Resolves #{issue_id}" and summary of all commits included
+
+### PR Review Comment Handling
+
+When addressing PR review comments:
+
+- **Locate the exact line**: Always check the line number specified in the review comment and examine the code at that exact location
+- **Understand the context**: Read the surrounding code and the comment body to understand what specific change is requested
+- **Implement at the correct location**: Make changes at the line/file specified in the review comment, not at similar-looking code elsewhere
+- **Verify the fix**: Ensure the change addresses the specific issue mentioned in the review comment
+- **Test thoroughly**: Run all tests and ensure the change doesn't break existing functionality
+- **Commit appropriately**: Use conventional commit prefixes (e.g., `fix:`, `refactor:`) based on the nature of the change

--- a/.clinerules/06-github-workflow.md
+++ b/.clinerules/06-github-workflow.md
@@ -46,9 +46,9 @@ When working on a GitHub issue (#X):
 
 When addressing PR review comments:
 
-- **Locate the exact line**: Always check the line number specified in the review comment and examine the code at that exact location
-- **Understand the context**: Read the surrounding code and the comment body to understand what specific change is requested
-- **Implement at the correct location**: Make changes at the line/file specified in the review comment, not at similar-looking code elsewhere
-- **Verify the fix**: Ensure the change addresses the specific issue mentioned in the review comment
-- **Test thoroughly**: Run all tests and ensure the change doesn't break existing functionality
-- **Commit appropriately**: Use conventional commit prefixes (e.g., `fix:`, `refactor:`) based on the nature of the change
+- Locate the exact line: Always check the line number specified in the review comment and examine the code at that exact location
+- Understand the context: Read the surrounding code and the comment body to understand what specific change is requested
+- Implement at the correct location: Make changes at the line/file specified in the review comment, not at similar-looking code elsewhere
+- Verify the fix: Ensure the change addresses the specific issue mentioned in the review comment
+- Test thoroughly: Run all tests and ensure the change doesn't break existing functionality
+- Commit appropriately: Use conventional commit prefixes (e.g., `fix:`, `refactor:`) based on the nature of the change

--- a/src/input.rs
+++ b/src/input.rs
@@ -183,22 +183,26 @@ impl Calculator {
                 // Get the current number being entered (could be parenthesized)
                 let current_part = &self.expression[last_op_pos + 1..];
 
-                // Try to parse as a regular number first
-                let num_value = if let Ok(value) = current_part.parse::<f64>() {
-                    Some(value)
-                } else if current_part.starts_with("(-") && current_part.ends_with(')') {
-                    // Try parsing as parenthesized negative number like "(-3)"
-                    current_part[1..current_part.len() - 1].parse::<f64>().ok()
-                } else if current_part.starts_with('-')
-                    && current_part.len() > 1
-                    && current_part[1..].starts_with("(-")
-                    && current_part.ends_with(')')
-                {
-                    // Try parsing as negative parenthesized number like "-(-3)"
-                    let inner = &current_part[2..current_part.len() - 1];
-                    inner.parse::<f64>().ok().map(|v| -v)
-                } else {
-                    None
+                // Try to parse different number formats using pattern matching
+                let num_value = match current_part {
+                    // Regular number
+                    s if s.parse::<f64>().is_ok() => s.parse::<f64>().ok(),
+                    // Parenthesized negative number like "(-3)"
+                    s if s.starts_with("(-") && s.ends_with(')') => {
+                        let inner = &s[2..s.len() - 1]; // Skip "(-" and ")"
+                        inner.parse::<f64>().ok().map(|v| -v)
+                    }
+                    // Negative parenthesized number like "-(-3)"
+                    s if s.starts_with('-')
+                        && s.len() > 3
+                        && s[1..].starts_with("(-")
+                        && s.ends_with(')') =>
+                    {
+                        let inner = &s[3..s.len() - 1]; // Skip "-(-" and ")"
+                        inner.parse::<f64>().ok()
+                    }
+                    // No valid format found
+                    _ => None,
                 };
 
                 if let Some(num_value) = num_value {

--- a/src/input.rs
+++ b/src/input.rs
@@ -170,14 +170,18 @@ impl Calculator {
 
     /// Handles sign toggle input for the calculator.
     pub fn handle_sign_toggle_input(&mut self) {
-        // Check if we're in the middle of entering an expression with an operator
-        // Exclude parentheses and only check for actual mathematical operators
-        let has_operators = self.expression.contains(|c: char| "+x÷".contains(c))
-            || (self.expression.contains('-')
-                && self.find_last_operator_position(&self.expression).is_some());
+        // Determine if we're toggling an operand within an expression or the entire expression
+        let has_operators = match (
+            self.expression.contains(|c: char| "+x÷".contains(c)),
+            self.expression.contains('-'),
+            self.find_last_operator_position(&self.expression),
+        ) {
+            (true, _, _) | (false, true, Some(_)) => true,
+            _ => false,
+        };
 
         if has_operators {
-            // There's an operator in the expression, so we're toggling the current operand
+            // Has operators - we're toggling an operand within an expression
             // Find the last operator position
             if let Some(last_op_pos) = self.find_last_operator_position(&self.expression) {
                 // Get the current number being entered (could be parenthesized)
@@ -222,7 +226,7 @@ impl Calculator {
                 }
             }
         } else {
-            // No operator, just toggle the sign of the entire expression
+            // No operators - just toggle the sign of the entire expression
             // Handle the display format which may include parentheses
             let (display_value, _is_from_parentheses) =
                 if self.display.starts_with("(-") && self.display.ends_with(')') {
@@ -236,7 +240,7 @@ impl Calculator {
                     // Regular number format
                     (value, false)
                 } else {
-                    return; // Cannot parse, do nothing
+                    return; // Invalid format, do nothing
                 };
 
             if display_value > 0.0 {

--- a/src/input.rs
+++ b/src/input.rs
@@ -263,23 +263,25 @@ impl Calculator {
 
         while i >= 0 {
             let c = chars[i as usize];
-            if c == ')' {
-                paren_depth += 1;
-            } else if c == '(' {
-                paren_depth -= 1;
-            } else if paren_depth == 0 && "+-x÷".contains(c) {
-                // We're at the top level and found an operator
-                // Check if this is a '-' that is a sign for a negative number
-                // A '-' is a negative sign if:
-                // 1. It's at the beginning of the expression (i == 0), OR
-                // 2. It's immediately after another operator
-                let is_negative_sign =
-                    c == '-' && (i == 0 || "+-x÷".contains(chars[(i - 1) as usize]));
-                if !is_negative_sign {
-                    // This is a separating operator
-                    return Some(i as usize);
+            match (paren_depth, c, i) {
+                (_, ')', _) => paren_depth += 1,
+                (_, '(', _) => paren_depth -= 1,
+                (0, c, _) if "+-x÷".contains(c) => {
+                    // We're at the top level and found an operator
+                    // Check if this is a '-' that is a sign for a negative number
+                    let is_negative_sign = match (c, i) {
+                        ('-', 0) => true, // '-' at the beginning of expression
+                        ('-', i) if i > 0 && "+-x÷".contains(chars[(i - 1) as usize]) => true, // '-' after another operator
+                        _ => false, // separating operator
+                    };
+
+                    if !is_negative_sign {
+                        // This is a separating operator
+                        return Some(i as usize);
+                    }
+                    // Skip this '-' as it's a sign
                 }
-                // Skip this '-' as it's a sign
+                _ => {} // Continue to next character
             }
             i -= 1;
         }

--- a/tests/input_tests.rs
+++ b/tests/input_tests.rs
@@ -312,6 +312,37 @@ fn test_user_reported_bug_steps() {
 }
 
 #[test]
+fn test_sign_toggle_after_subtraction_bug() {
+    // Test the specific bug reported in issue #12
+    let mut calc = Calculator::new();
+
+    // 1. Press `5`
+    calc.handle_number_input(5);
+    assert_eq!(calc.expression, "5");
+    assert_eq!(calc.display, "5");
+
+    // 2. Press `-`
+    calc.handle_operation_input(Operation::Subtract);
+    assert_eq!(calc.expression, "5-");
+    assert_eq!(calc.display, "5-");
+
+    // 3. Press `3`
+    calc.handle_number_input(3);
+    assert_eq!(calc.expression, "5-3");
+    assert_eq!(calc.display, "5-3");
+
+    // 4. Press `+/-` - this should toggle the sign of 3 to become "5-(-3)"
+    calc.handle_sign_toggle_input();
+    assert_eq!(calc.expression, "5-(-3)");
+    assert_eq!(calc.display, "5-(-3)");
+
+    // 5. Press `+/-` again - this should toggle back to "5-3"
+    calc.handle_sign_toggle_input();
+    assert_eq!(calc.expression, "5-3");
+    assert_eq!(calc.display, "5-3");
+}
+
+#[test]
 fn test_handle_clear_input() {
     let mut calc = Calculator::new();
     calc.expression = "123+456".to_string();


### PR DESCRIPTION
Fixes #12: Sign toggle key does not function when the current number is preceded by a subtraction operator.

## Problem
When input is `5-3` and user presses the sign toggle key (+/-), nothing happens instead of the expected behavior of changing to `5-(-3)`.

## Root Cause
The `find_last_operator_position` function incorrectly identified '-' characters inside expressions as negative signs rather than subtraction operators. Additionally, the parsing logic didn't handle parenthesized negative numbers like `-(-3)`.

## Solution
1. Fixed `find_last_operator_position` to properly handle parentheses and distinguish between negative signs and separating operators
2. Added parsing logic for negative parenthesized numbers in the sign toggle function
3. Added comprehensive test case covering the bug scenario

## Testing
- All existing tests pass
- New test case `test_sign_toggle_after_subtraction_bug` verifies the fix
- Code passes clippy and fmt checks

Resolves #12